### PR TITLE
Fix page-ref-link color after break in latest roam

### DIFF
--- a/roam-style.css
+++ b/roam-style.css
@@ -170,7 +170,7 @@ span.bp3-icon-small.bp3-icon-star {
 .rm-page-ref {
     color: #9aabd0;
 }
-.rm-page-ref-link-color {
+.rm-page-ref-link-color, .rm-page-ref--link {
     color: #33bdea;
     font-weight: 600;
 }


### PR DESCRIPTION
adds a `.rm-page-ref-link-color` seems to have changed to `.rm-page-ref--link` in recent versions of roam.